### PR TITLE
Fix: use formatArgs instead of formatArg

### DIFF
--- a/src/testers.js
+++ b/src/testers.js
@@ -1,9 +1,9 @@
-module.exports = (hre,formatArgs,assert) => {
+module.exports = (hre,formatArg,assert) => {
   /** Fail if event signals test failure. */
   const genericFail = ({ success, actual, expected, message }) => {
     if (!success) {
       assert.fail(
-        `${message}\nActual:   ${formatArgs(actual)}\nExpected: ${formatArgs(
+        `${message}\nActual:   ${formatArg(actual)}\nExpected: ${formatArg(
           expected
         )}`
       );

--- a/src/testers.js
+++ b/src/testers.js
@@ -3,7 +3,7 @@ module.exports = (hre,formatArgs,assert) => {
   const genericFail = ({ success, actual, expected, message }) => {
     if (!success) {
       assert.fail(
-        `${message}\nActual:   ${formatArg(actual)}\nExpected: ${formatArg(
+        `${message}\nActual:   ${formatArgs(actual)}\nExpected: ${formatArgs(
           expected
         )}`
       );


### PR DESCRIPTION
There was a spelling mistake that was breaking the tests when expected != actual